### PR TITLE
True multi-arch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ ENV BUILDAH_ISOLATION=chroot
 ENV KUBECTL_VERSION=v1.18.6
 ENV HELM_VERSION=v3.2.4
 ENV HOME=/home/theia
-ENV TEKTONCD_VERSION=0.10.0
 
 RUN mkdir /projects ${HOME} && \
     # Change permissions to let any arbitrary user
@@ -46,11 +45,7 @@ RUN mkdir /projects ${HOME} && \
       then export ARCH_K8S_HELM="arm64"; fi && \
     curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH_K8S_HELM}/kubectl -o /usr/local/bin/kubectl && \
     curl -o- -L https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH_K8S_HELM}.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
-    # ppc64le support coming to tekton in version 0.11.0
-    export ARCH_TEKTON="$(uname -m)" && if [[ ${ARCH_TEKTON} == "aarch64" ]]; then export ARCH_TEKTON="arm64"; fi && \
-    curl -LO https://github.com/tektoncd/cli/releases/download/v${TEKTONCD_VERSION}/tkn_${TEKTONCD_VERSION}_Linux_${ARCH_TEKTON}.tar.gz && \
-    tar xvzf tkn_${TEKTONCD_VERSION}_Linux_${ARCH_TEKTON}.tar.gz -C /usr/local/bin/ tkn && \
-    chmod +x /usr/local/bin/kubectl /usr/local/bin/helm /usr/local/bin/tkn
+    chmod +x /usr/local/bin/kubectl /usr/local/bin/helm
 
 ADD etc/entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV BUILDAH_ISOLATION=chroot
 ENV KUBECTL_VERSION=v1.18.6
 ENV HELM_VERSION=v3.2.4
 ENV HOME=/home/theia
-ENV TEKTONCD_VERSION=0.9.0
+ENV TEKTONCD_VERSION=0.10.0
 
 RUN mkdir /projects ${HOME} && \
     # Change permissions to let any arbitrary user
@@ -42,13 +42,12 @@ RUN mkdir /projects ${HOME} && \
       echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
       chmod -R g+rwX ${f}; \
     done && \
-    export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH_K8S_HELM="amd64"; elif [[ ${ARCH} == "aarch64" ]]; \
-      then export ARCH_K8S_HELM="arm64"; elif [[ ${ARCH} == "s390x" ]]; then export ARCH_K8S_HELM="s390x"; elif [[ ${ARCH} == "ppc64le" ]]; \
-      then export ARCH_K8S_HELM="ppc64le"; fi && \
+    export ARCH_K8S_HELM="$(uname -m)" && if [[ ${ARCH_K8S_HELM} == "x86_64" ]]; then export ARCH_K8S_HELM="amd64"; elif [[ ${ARCH_K8S_HELM} == "aarch64" ]]; \
+      then export ARCH_K8S_HELM="arm64"; fi && \
     curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH_K8S_HELM}/kubectl -o /usr/local/bin/kubectl && \
     curl -o- -L https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH_K8S_HELM}.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
-    export ARCH_TEKTON="$(uname -m)" && \
-    echo $ARCH_TEKTON && \
+    # ppc64le support coming to tekton in version 0.11.0
+    export ARCH_TEKTON="$(uname -m)" && if [[ ${ARCH_TEKTON} == "aarch64" ]]; then export ARCH_TEKTON="arm64"; fi && \
     curl -LO https://github.com/tektoncd/cli/releases/download/v${TEKTONCD_VERSION}/tkn_${TEKTONCD_VERSION}_Linux_${ARCH_TEKTON}.tar.gz && \
     tar xvzf tkn_${TEKTONCD_VERSION}_Linux_${ARCH_TEKTON}.tar.gz -C /usr/local/bin/ tkn && \
     chmod +x /usr/local/bin/kubectl /usr/local/bin/helm /usr/local/bin/tkn

--- a/PLATFORMS
+++ b/PLATFORMS
@@ -1,1 +1,1 @@
-linux/amd64,linux/ppc64le,linux/s390x,linux/arm64
+linux/amd64,linux/s390x,linux/arm64

--- a/PLATFORMS
+++ b/PLATFORMS
@@ -1,1 +1,1 @@
-linux/amd64,linux/s390x,linux/arm64
+linux/amd64,linux/ppc64le,linux/s390x,linux/arm64


### PR DESCRIPTION
buildah doesn't publish multi-arch images, so all images using it as a base will be x86_64 by default. Instead, we create the buildah env ourselves using a fedora multi-arch image.

Signed-off-by: Eric Williams <ericwill@redhat.com>